### PR TITLE
Validaçao user @smartflix.com.br

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   enum role: { user: 0, teacher: 5, admin: 10 }
 
+  validate :only_create_if_company_domain
+
   after_create :define_admin
 
   private
@@ -13,5 +15,10 @@ class User < ApplicationRecord
   def define_admin
     domain = email.split('@').last
     admin! if domain == 'smartflix.com.br'
+  end
+
+  def only_create_if_company_domain
+    domain = email.split('@').last
+    errors.add(:email, 'Apenas emails autorizados') unless domain == 'smartflix.com.br'
   end
 end

--- a/spec/features/admin_create_class_category_spec.rb
+++ b/spec/features/admin_create_class_category_spec.rb
@@ -81,23 +81,4 @@ feature 'Admin create class category' do
     expect(page).not_to have_content('Cadastrar nova Categoria de Aula')
     expect(page).to have_content('Não podemos cadastrar esta categoria no momento')
   end
-
-  scenario 'and only admin can create class categories' do
-    allow(PaymentMethod).to receive(:all).and_return([])
-    user = create(:user, email: 'julia@flix.com.br')
-    login_as user
-    visit root_path
-
-    expect(page).not_to have_content('Cadastrar Categoria de Aulas')
-  end
-
-  scenario 'and common user cannot access from path' do
-    allow(PaymentMethod).to receive(:all).and_return([])
-    user = create(:user, email: 'julia@flix.com.br')
-    login_as user
-
-    visit class_categories_path
-
-    expect(current_path).to eq root_path
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,16 +2,19 @@ require 'rails_helper'
 
 describe User do
   context 'Validation' do
-    it 'should automatically insert account with domain @smartflix in admin' do
+    it 'user must have domain @smartflix' do
       user = create(:user, email: 'maria@smartflix.com.br')
 
       expect(user.role).to eq 'admin'
+      expect(User.last).to eq user
     end
 
-    it 'should register other accounts as role user' do
-      user = create(:user, email: 'maria@flix.com.br')
+    it 'cannot create user account if domain is not @smartflix.com.br' do
+      valid_user = create(:user, email: 'maria@smartflix.com.br')
+      invalid_user = User.create(email: 'maria@flix.com.br', password: '123456')
 
-      expect(user.role).to eq 'user'
+      expect(invalid_user.valid?).to eq false
+      expect(User.last).to eq valid_user
     end
   end
 end


### PR DESCRIPTION
Este PR implementa  uma validação extra no cadastro de usuário, para impedir que pessoas sem e-mail @smartflix criem uma conta de usuário no sistema de matrículas. 